### PR TITLE
Discarding the master/slave jargon

### DIFF
--- a/cinder/api/contrib/extended_snapshot_attributes.py
+++ b/cinder/api/contrib/extended_snapshot_attributes.py
@@ -38,7 +38,7 @@ class ExtendedSnapshotAttributesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['cinder.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedSnapshotAttributeTemplate())
             snapshot = resp_obj.obj['snapshot']
             self._extend_snapshot(req, snapshot)
@@ -47,7 +47,7 @@ class ExtendedSnapshotAttributesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['cinder.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedSnapshotAttributesTemplate())
             for snapshot in list(resp_obj.obj['snapshots']):
                 self._extend_snapshot(req, snapshot)
@@ -82,7 +82,7 @@ class ExtendedSnapshotAttributeTemplate(xmlutil.TemplateBuilder):
         make_snapshot(root)
         alias = Extended_snapshot_attributes.alias
         namespace = Extended_snapshot_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class ExtendedSnapshotAttributesTemplate(xmlutil.TemplateBuilder):
@@ -93,4 +93,4 @@ class ExtendedSnapshotAttributesTemplate(xmlutil.TemplateBuilder):
         make_snapshot(elem)
         alias = Extended_snapshot_attributes.alias
         namespace = Extended_snapshot_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})

--- a/cinder/api/contrib/volume_type_access.py
+++ b/cinder/api/contrib/volume_type_access.py
@@ -46,7 +46,7 @@ class VolumeTypeTemplate(xmlutil.TemplateBuilder):
         make_volume_type(root)
         alias = Volume_type_access.alias
         namespace = Volume_type_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class VolumeTypesTemplate(xmlutil.TemplateBuilder):
@@ -57,7 +57,7 @@ class VolumeTypesTemplate(xmlutil.TemplateBuilder):
         make_volume_type(elem)
         alias = Volume_type_access.alias
         namespace = Volume_type_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class VolumeTypeAccessTemplate(xmlutil.TemplateBuilder):
@@ -66,7 +66,7 @@ class VolumeTypeAccessTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'access',
                                           selector='volume_type_access')
         make_volume_type_access(elem)
-        return xmlutil.MasterTemplate(root, 1)
+        return xmlutil.MainTemplate(root, 1)
 
 
 def _marshall_volume_type_access(vol_type):
@@ -123,7 +123,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['cinder.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypeTemplate())
             vol_type = req.cached_resource_by_id(id, name='types')
             self._extend_vol_type(resp_obj.obj['volume_type'], vol_type)
@@ -132,7 +132,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def index(self, req, resp_obj):
         context = req.environ['cinder.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypesTemplate())
             for vol_type_rval in list(resp_obj.obj['volume_types']):
                 type_id = vol_type_rval['id']
@@ -143,7 +143,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['cinder.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypesTemplate())
             for vol_type_rval in list(resp_obj.obj['volume_types']):
                 type_id = vol_type_rval['id']
@@ -154,7 +154,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def create(self, req, body, resp_obj):
         context = req.environ['cinder.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypeTemplate())
             type_id = resp_obj.obj['volume_type']['id']
             vol_type = req.cached_resource_by_id(type_id, name='types')

--- a/cinder/api/openstack/wsgi.py
+++ b/cinder/api/openstack/wsgi.py
@@ -653,7 +653,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/cinder/api/xmlutil.py
+++ b/cinder/api/xmlutil.py
@@ -701,13 +701,13 @@ class Template(object):
         # We are a template
         return self
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.
+        is applicable as a subordinate to a given main template.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
         return True
@@ -722,17 +722,17 @@ class Template(object):
         return "%r: %s" % (self, self.root.tree())
 
 
-class MasterTemplate(Template):
-    """Represent a master template.
+class MainTemplate(Template):
+    """Represent a main template.
 
-    Master templates are versioned derivatives of templates that
-    additionally allow slave templates to be attached.  Slave
+    Main templates are versioned derivatives of templates that
+    additionally allow subordinate templates to be attached.  Subordinate
     templates allow modification of the serialized result without
-    directly changing the master.
+    directly changing the main.
     """
 
     def __init__(self, root, version, nsmap=None):
-        """Initialize a master template.
+        """Initialize a main template.
 
         :param root: The root element of the template.
         :param version: The version number of the template.
@@ -741,9 +741,9 @@ class MasterTemplate(Template):
                       template.
         """
 
-        super(MasterTemplate, self).__init__(root, nsmap)
+        super(MainTemplate, self).__init__(root, nsmap)
         self.version = version
-        self.slaves = []
+        self.subordinates = []
 
     def __repr__(self):
         """Return string representation of the template."""
@@ -757,89 +757,89 @@ class MasterTemplate(Template):
 
         An overridable hook method to return the siblings of the root
         element.  This is the root element plus the root elements of
-        all the slave templates.
+        all the subordinate templates.
         """
 
-        return [self.root] + [slave.root for slave in self.slaves]
+        return [self.root] + [subordinate.root for subordinate in self.subordinates]
 
     def _nsmap(self):
         """Hook method for computing the namespace dictionary.
 
         An overridable hook method to return the namespace dictionary.
-        The namespace dictionary is computed by taking the master
+        The namespace dictionary is computed by taking the main
         template's namespace dictionary and updating it from all the
-        slave templates.
+        subordinate templates.
         """
 
         nsmap = self.nsmap.copy()
-        for slave in self.slaves:
-            nsmap.update(slave._nsmap())
+        for subordinate in self.subordinates:
+            nsmap.update(subordinate._nsmap())
         return nsmap
 
-    def attach(self, *slaves):
-        """Attach one or more slave templates.
+    def attach(self, *subordinates):
+        """Attach one or more subordinate templates.
 
-        Attaches one or more slave templates to the master template.
-        Slave templates must have a root element with the same tag as
-        the master template.  The slave template's apply() method will
-        be called to determine if the slave should be applied to this
-        master; if it returns False, that slave will be skipped.
-        (This allows filtering of slaves based on the version of the
-        master template.)
+        Attaches one or more subordinate templates to the main template.
+        Subordinate templates must have a root element with the same tag as
+        the main template.  The subordinate template's apply() method will
+        be called to determine if the subordinate should be applied to this
+        main; if it returns False, that subordinate will be skipped.
+        (This allows filtering of subordinates based on the version of the
+        main template.)
         """
 
-        slave_list = []
-        for slave in slaves:
-            slave = slave.wrap()
+        subordinate_list = []
+        for subordinate in subordinates:
+            subordinate = subordinate.wrap()
 
             # Make sure we have a tree match
-            if slave.root.tag != self.root.tag:
-                msg = (_("Template tree mismatch; adding slave %(slavetag)s "
-                         "to master %(mastertag)s") %
-                       {'slavetag': slave.root.tag,
-                        'mastertag': self.root.tag})
+            if subordinate.root.tag != self.root.tag:
+                msg = (_("Template tree mismatch; adding subordinate %(subordinatetag)s "
+                         "to main %(maintag)s") %
+                       {'subordinatetag': subordinate.root.tag,
+                        'maintag': self.root.tag})
                 raise ValueError(msg)
 
-            # Make sure slave applies to this template
-            if not slave.apply(self):
+            # Make sure subordinate applies to this template
+            if not subordinate.apply(self):
                 continue
 
-            slave_list.append(slave)
+            subordinate_list.append(subordinate)
 
-        # Add the slaves
-        self.slaves.extend(slave_list)
+        # Add the subordinates
+        self.subordinates.extend(subordinate_list)
 
     def copy(self):
-        """Return a copy of this master template."""
+        """Return a copy of this main template."""
 
-        # Return a copy of the MasterTemplate
+        # Return a copy of the MainTemplate
         tmp = self.__class__(self.root, self.version, self.nsmap)
-        tmp.slaves = self.slaves[:]
+        tmp.subordinates = self.subordinates[:]
         return tmp
 
 
-class SlaveTemplate(Template):
-    """Represent a slave template.
+class SubordinateTemplate(Template):
+    """Represent a subordinate template.
 
-    Slave templates are versioned derivatives of templates.  Each
-    slave has a minimum version and optional maximum version of the
-    master template to which they can be attached.
+    Subordinate templates are versioned derivatives of templates.  Each
+    subordinate has a minimum version and optional maximum version of the
+    main template to which they can be attached.
     """
 
     def __init__(self, root, min_vers, max_vers=None, nsmap=None):
-        """Initialize a slave template.
+        """Initialize a subordinate template.
 
         :param root: The root element of the template.
-        :param min_vers: The minimum permissible version of the master
-                         template for this slave template to apply.
-        :param max_vers: An optional upper bound for the master
+        :param min_vers: The minimum permissible version of the main
+                         template for this subordinate template to apply.
+        :param max_vers: An optional upper bound for the main
                          template version.
         :param nsmap: An optional namespace dictionary to be
                       associated with the root element of the
                       template.
         """
 
-        super(SlaveTemplate, self).__init__(root, nsmap)
+        super(SubordinateTemplate, self).__init__(root, nsmap)
         self.min_vers = min_vers
         self.max_vers = max_vers
 
@@ -850,23 +850,23 @@ class SlaveTemplate(Template):
                 (self.__class__.__module__, self.__class__.__name__,
                  self.min_vers, self.max_vers, id(self)))
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.  This
-        version requires the master template to have a version number
+        is applicable as a subordinate to a given main template.  This
+        version requires the main template to have a version number
         between min_vers and max_vers.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
-        # Does the master meet our minimum version requirement?
-        if master.version < self.min_vers:
+        # Does the main meet our minimum version requirement?
+        if main.version < self.min_vers:
             return False
 
         # How about our maximum version requirement?
-        if self.max_vers is not None and master.version > self.max_vers:
+        if self.max_vers is not None and main.version > self.max_vers:
             return False
 
         return True

--- a/cinder/openstack/common/gettextutils.py
+++ b/cinder/openstack/common/gettextutils.py
@@ -331,9 +331,9 @@ def get_available_languages(domain):
     # order matters) since our in-line message strings are en_US
     language_list = ['en_US']
     # NOTE(luisg): Babel <1.0 used a function called list(), which was
-    # renamed to locale_identifiers() in >=1.0, the requirements master list
+    # renamed to locale_identifiers() in >=1.0, the requirements main list
     # requires >=0.9.6, uncapped, so defensively work with both. We can remove
-    # this check when the master list updates to >=1.0, and update all projects
+    # this check when the main list updates to >=1.0, and update all projects
     list_identifiers = (getattr(localedata, 'list', None) or
                         getattr(localedata, 'locale_identifiers'))
     locale_identifiers = list_identifiers()

--- a/cinder/tests/unit/api/test_xmlutil.py
+++ b/cinder/tests/unit/api/test_xmlutil.py
@@ -364,15 +364,15 @@ class TemplateElementTest(test.TestCase):
                      attr2=xmlutil.ConstantSelector(2),
                      attr3=xmlutil.ConstantSelector(3))
 
-        # Create a master template element
-        master_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
+        # Create a main template element
+        main_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
 
-        # Create a couple of slave template element
-        slave_elems = [xmlutil.TemplateElement('test', attr2=attrs['attr2']),
+        # Create a couple of subordinate template element
+        subordinate_elems = [xmlutil.TemplateElement('test', attr2=attrs['attr2']),
                        xmlutil.TemplateElement('test', attr3=attrs['attr3']), ]
 
         # Try the render
-        elem = master_elem._render(None, None, slave_elems, None)
+        elem = main_elem._render(None, None, subordinate_elems, None)
 
         # Verify the particulars of the render
         self.assertEqual('test', elem.tag)
@@ -384,7 +384,7 @@ class TemplateElementTest(test.TestCase):
         parent = etree.Element('parent')
 
         # Try the render again...
-        elem = master_elem._render(parent, None, slave_elems, dict(a='foo'))
+        elem = main_elem._render(parent, None, subordinate_elems, dict(a='foo'))
 
         # Verify the particulars of the render
         self.assertEqual(1, len(parent))
@@ -495,46 +495,46 @@ class TemplateTest(test.TestCase):
         self.assertEqual(1, len(nsmap))
         self.assertEqual('foo', nsmap['a'])
 
-    def test_master_attach(self):
-        # Set up a master template
+    def test_main_attach(self):
+        # Set up a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1)
+        tmpl = xmlutil.MainTemplate(elem, 1)
 
-        # Make sure it has a root but no slaves
+        # Make sure it has a root but no subordinates
         self.assertEqual(elem, tmpl.root)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
-        # Try to attach an invalid slave
+        # Try to attach an invalid subordinate
         bad_elem = xmlutil.TemplateElement('test2')
         self.assertRaises(ValueError, tmpl.attach, bad_elem)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
-        # Try to attach an invalid and a valid slave
+        # Try to attach an invalid and a valid subordinate
         good_elem = xmlutil.TemplateElement('test')
         self.assertRaises(ValueError, tmpl.attach, good_elem, bad_elem)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
         # Try to attach an inapplicable template
         class InapplicableTemplate(xmlutil.Template):
-            def apply(self, master):
+            def apply(self, main):
                 return False
         inapp_tmpl = InapplicableTemplate(good_elem)
         tmpl.attach(inapp_tmpl)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
         # Now try attaching an applicable template
         tmpl.attach(good_elem)
-        self.assertEqual(1, len(tmpl.slaves))
-        self.assertEqual(good_elem, tmpl.slaves[0].root)
+        self.assertEqual(1, len(tmpl.subordinates))
+        self.assertEqual(good_elem, tmpl.subordinates[0].root)
 
-    def test_master_copy(self):
-        # Construct a master template
+    def test_main_copy(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1, nsmap=dict(a='foo'))
+        tmpl = xmlutil.MainTemplate(elem, 1, nsmap=dict(a='foo'))
 
-        # Give it a slave
-        slave = xmlutil.TemplateElement('test')
-        tmpl.attach(slave)
+        # Give it a subordinate
+        subordinate = xmlutil.TemplateElement('test')
+        tmpl.attach(subordinate)
 
         # Construct a copy
         copy = tmpl.copy()
@@ -544,42 +544,42 @@ class TemplateTest(test.TestCase):
         self.assertEqual(tmpl.root, copy.root)
         self.assertEqual(tmpl.version, copy.version)
         self.assertEqual(id(tmpl.nsmap), id(copy.nsmap))
-        self.assertNotEqual(id(tmpl.slaves), id(copy.slaves))
-        self.assertEqual(len(tmpl.slaves), len(copy.slaves))
-        self.assertEqual(tmpl.slaves[0], copy.slaves[0])
+        self.assertNotEqual(id(tmpl.subordinates), id(copy.subordinates))
+        self.assertEqual(len(tmpl.subordinates), len(copy.subordinates))
+        self.assertEqual(tmpl.subordinates[0], copy.subordinates[0])
 
-    def test_slave_apply(self):
-        # Construct a master template
+    def test_subordinate_apply(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        master = xmlutil.MasterTemplate(elem, 3)
+        main = xmlutil.MainTemplate(elem, 3)
 
-        # Construct a slave template with applicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 2)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with applicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 2)
+        self.assertTrue(subordinate.apply(main))
 
-        # Construct a slave template with equal minimum version
-        slave = xmlutil.SlaveTemplate(elem, 3)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with equal minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 3)
+        self.assertTrue(subordinate.apply(main))
 
-        # Construct a slave template with inapplicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 4)
-        self.assertFalse(slave.apply(master))
+        # Construct a subordinate template with inapplicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 4)
+        self.assertFalse(subordinate.apply(main))
 
-        # Construct a slave template with applicable version range
-        slave = xmlutil.SlaveTemplate(elem, 2, 4)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with applicable version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 2, 4)
+        self.assertTrue(subordinate.apply(main))
 
-        # Construct a slave template with low version range
-        slave = xmlutil.SlaveTemplate(elem, 1, 2)
-        self.assertFalse(slave.apply(master))
+        # Construct a subordinate template with low version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 1, 2)
+        self.assertFalse(subordinate.apply(main))
 
-        # Construct a slave template with high version range
-        slave = xmlutil.SlaveTemplate(elem, 4, 5)
-        self.assertFalse(slave.apply(master))
+        # Construct a subordinate template with high version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 4, 5)
+        self.assertFalse(subordinate.apply(main))
 
-        # Construct a slave template with matching version range
-        slave = xmlutil.SlaveTemplate(elem, 3, 3)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with matching version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 3, 3)
+        self.assertTrue(subordinate.apply(main))
 
     def test__serialize(self):
         # Our test object to serialize
@@ -591,7 +591,7 @@ class TemplateTest(test.TestCase):
                                   'd': 4, },
                         'image': {'name': 'image_foobar', 'id': 42, }, }, }
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
         value = xmlutil.SubTemplateElement(root, 'value', selector='values')
@@ -599,22 +599,22 @@ class TemplateTest(test.TestCase):
         attrs = xmlutil.SubTemplateElement(root, 'attrs', selector='attrs')
         xmlutil.SubTemplateElement(attrs, 'attr', selector=xmlutil.get_items,
                                    key=0, value=1)
-        master = xmlutil.MasterTemplate(root, 1, nsmap=dict(f='foo'))
+        main = xmlutil.MainTemplate(root, 1, nsmap=dict(f='foo'))
 
-        # Set up our slave template
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        # Set up our subordinate template
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image', id='id')
         image.text = xmlutil.Selector('name')
-        slave = xmlutil.SlaveTemplate(root_slave, 1, nsmap=dict(b='bar'))
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1, nsmap=dict(b='bar'))
 
-        # Attach the slave to the master...
-        master.attach(slave)
+        # Attach the subordinate to the main...
+        main.attach(subordinate)
 
         # Try serializing our object
-        siblings = master._siblings()
-        nsmap = master._nsmap()
-        result = master._serialize(None, obj, siblings, nsmap)
+        siblings = main._siblings()
+        nsmap = main._nsmap()
+        result = main._serialize(None, obj, siblings, nsmap)
 
         # Now we get to manually walk the element tree...
         self.assertEqual('test', result.tag)
@@ -644,7 +644,7 @@ class TemplateTest(test.TestCase):
                         'scope0:scope1:scope2:key3': 'Value3'
                         }}
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test')
         key1 = xmlutil.SubTemplateElement(root, 'scope0:key1',
                                           selector='scope0:key1')
@@ -655,7 +655,7 @@ class TemplateTest(test.TestCase):
         key3 = xmlutil.SubTemplateElement(root, 'scope0:scope1:scope2:key3',
                                           selector='scope0:scope1:scope2:key3')
         key3.text = xmlutil.Selector()
-        serializer = xmlutil.MasterTemplate(root, 1)
+        serializer = xmlutil.MainTemplate(root, 1)
         xml_list = []
         xml_list.append("<?xmlversion='1.0'encoding='UTF-8'?><test>")
         xml_list.append("<scope0><key1>Value1</key1><scope1>")
@@ -667,60 +667,60 @@ class TemplateTest(test.TestCase):
         self.assertEqual(expected_xml, result)
 
 
-class MasterTemplateBuilder(xmlutil.TemplateBuilder):
+class MainTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.MasterTemplate(elem, 1)
+        return xmlutil.MainTemplate(elem, 1)
 
 
-class SlaveTemplateBuilder(xmlutil.TemplateBuilder):
+class SubordinateTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.SlaveTemplate(elem, 1)
+        return xmlutil.SubordinateTemplate(elem, 1)
 
 
 class TemplateBuilderTest(test.TestCase):
-    def test_master_template_builder(self):
+    def test_main_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNone(MainTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = MasterTemplateBuilder()
+        tmpl1 = MainTemplateBuilder()
 
         # Make sure that there is a template cached...
-        self.assertIsNotNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNotNone(MainTemplateBuilder._tmpl)
 
         # Make sure it wasn't what was returned...
-        self.assertNotEqual(MasterTemplateBuilder._tmpl, tmpl1)
+        self.assertNotEqual(MainTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        cached = MasterTemplateBuilder._tmpl
-        tmpl2 = MasterTemplateBuilder()
-        self.assertEqual(MasterTemplateBuilder._tmpl, cached)
+        cached = MainTemplateBuilder._tmpl
+        tmpl2 = MainTemplateBuilder()
+        self.assertEqual(MainTemplateBuilder._tmpl, cached)
 
         # Make sure we're always getting fresh copies
         self.assertNotEqual(tmpl1, tmpl2)
 
         # Make sure we can override the copying behavior
-        tmpl3 = MasterTemplateBuilder(False)
-        self.assertEqual(MasterTemplateBuilder._tmpl, tmpl3)
+        tmpl3 = MainTemplateBuilder(False)
+        self.assertEqual(MainTemplateBuilder._tmpl, tmpl3)
 
-    def test_slave_template_builder(self):
+    def test_subordinate_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNone(SubordinateTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = SlaveTemplateBuilder()
+        tmpl1 = SubordinateTemplateBuilder()
 
         # Make sure there is a template cached...
-        self.assertIsNotNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNotNone(SubordinateTemplateBuilder._tmpl)
 
         # Make sure it was what was returned...
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        tmpl2 = SlaveTemplateBuilder()
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        tmpl2 = SubordinateTemplateBuilder()
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure we're always getting the cached copy
         self.assertEqual(tmpl1, tmpl2)
@@ -731,6 +731,6 @@ class MiscellaneousXMLUtilTests(test.TestCase):
         expected_xml = ("<?xml version='1.0' encoding='UTF-8'?>\n"
                         '<wrapper><a>foo</a><b>bar</b></wrapper>')
         root = xmlutil.make_flat_dict('wrapper')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo', b='bar')))
         self.assertEqual(expected_xml, result)

--- a/cinder/tests/unit/test_storwize_svc.py
+++ b/cinder/tests/unit/test_storwize_svc.py
@@ -2558,29 +2558,29 @@ class StorwizeSVCDriverTestCase(test.TestCase):
 
     def test_storwize_svc_delete_volume_snapshots(self):
         # Create a volume with two snapshots
-        master = self._create_volume()
+        main = self._create_volume()
 
         # Fail creating a snapshot - will force delete the snapshot
         if self.USESIM and False:
-            snap = self._generate_vol_info(master['name'], master['id'])
+            snap = self._generate_vol_info(main['name'], main['id'])
             self.sim.error_injection('startfcmap', 'bad_id')
             self.assertRaises(exception.VolumeBackendAPIException,
                               self.driver.create_snapshot, snap)
             self._assert_vol_exists(snap['name'], False)
 
         # Delete a snapshot
-        snap = self._generate_vol_info(master['name'], master['id'])
+        snap = self._generate_vol_info(main['name'], main['id'])
         self.driver.create_snapshot(snap)
         self._assert_vol_exists(snap['name'], True)
         self.driver.delete_snapshot(snap)
         self._assert_vol_exists(snap['name'], False)
 
         # Delete a volume with snapshots (regular)
-        snap = self._generate_vol_info(master['name'], master['id'])
+        snap = self._generate_vol_info(main['name'], main['id'])
         self.driver.create_snapshot(snap)
         self._assert_vol_exists(snap['name'], True)
-        self.driver.delete_volume(master)
-        self._assert_vol_exists(master['name'], False)
+        self.driver.delete_volume(main)
+        self._assert_vol_exists(main['name'], False)
 
         # Fail create volume from snapshot - will force delete the volume
         if self.USESIM:

--- a/cinder/tests/unit/test_v6000_fcp.py
+++ b/cinder/tests/unit/test_v6000_fcp.py
@@ -516,7 +516,7 @@ class V6000FCPDriverTestCase(test.TestCase):
         vendor_name = "Violin Memory, Inc."
         tot_bytes = 100 * units.Gi
         free_bytes = 50 * units.Gi
-        bn0 = '/cluster/state/master_id'
+        bn0 = '/cluster/state/main_id'
         bn1 = "/vshare/state/global/1/container/myContainer/total_bytes"
         bn2 = "/vshare/state/global/1/container/myContainer/free_bytes"
         response1 = {bn0: '1'}
@@ -541,7 +541,7 @@ class V6000FCPDriverTestCase(test.TestCase):
     def test_update_stats_fails_data_query(self):
         backend_name = self.conf.volume_backend_name
         vendor_name = "Violin Memory, Inc."
-        bn0 = '/cluster/state/master_id'
+        bn0 = '/cluster/state/main_id'
         response1 = {bn0: '1'}
         response2 = {}
 
@@ -561,7 +561,7 @@ class V6000FCPDriverTestCase(test.TestCase):
         """Stats query to backend fails, but cached stats are available. """
         backend_name = self.conf.volume_backend_name
         vendor_name = "Violin Memory, Inc."
-        bn0 = '/cluster/state/master_id'
+        bn0 = '/cluster/state/main_id'
         response1 = {bn0: '1'}
         response2 = {}
 

--- a/cinder/tests/unit/test_v6000_iscsi.py
+++ b/cinder/tests/unit/test_v6000_iscsi.py
@@ -521,7 +521,7 @@ class V6000ISCSIDriverTestCase(test.TestCase):
         vendor_name = "Violin Memory, Inc."
         tot_bytes = 100 * units.Gi
         free_bytes = 50 * units.Gi
-        bn0 = '/cluster/state/master_id'
+        bn0 = '/cluster/state/main_id'
         bn1 = "/vshare/state/global/1/container/myContainer/total_bytes"
         bn2 = "/vshare/state/global/1/container/myContainer/free_bytes"
         response1 = {bn0: '1'}
@@ -546,7 +546,7 @@ class V6000ISCSIDriverTestCase(test.TestCase):
     def test_update_stats_fails_data_query(self):
         backend_name = self.conf.volume_backend_name
         vendor_name = "Violin Memory, Inc."
-        bn0 = '/cluster/state/master_id'
+        bn0 = '/cluster/state/main_id'
         response1 = {bn0: '1'}
         response2 = {}
 
@@ -566,7 +566,7 @@ class V6000ISCSIDriverTestCase(test.TestCase):
         """Stats query to backend fails, but cached stats are available. """
         backend_name = self.conf.volume_backend_name
         vendor_name = "Violin Memory, Inc."
-        bn0 = '/cluster/state/master_id'
+        bn0 = '/cluster/state/main_id'
         response1 = {bn0: '1'}
         response2 = {}
 

--- a/cinder/tests/unit/volume/drivers/test_hgst.py
+++ b/cinder/tests/unit/volume/drivers/test_hgst.py
@@ -747,7 +747,7 @@ IP_OUTPUT = """
        valid_lft forever preferred_lft forever
     inet6 ::1/128 scope host
        valid_lft forever preferred_lft forever
-2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master
+2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq main
     link/ether 00:25:90:d9:18:08 brd ff:ff:ff:ff:ff:ff
     inet6 fe80::225:90ff:fed9:1808/64 scope link
        valid_lft forever preferred_lft forever
@@ -798,7 +798,7 @@ HGST_HOST_STORAGE = """
         "ipDataProviderLoaded": true,
         "ibDataProviderLoaded": false,
         "driverUptimeSecs": 4800,
-        "rVersion": "20368.d55ec22.master"
+        "rVersion": "20368.d55ec22.main"
       },
       "totalCapacityBytes": 98213822464,
       "totalUsedBytes": 3266781184,
@@ -818,7 +818,7 @@ HGST_HOST_STORAGE = """
         "ipDataProviderLoaded": true,
         "ibDataProviderLoaded": false,
         "driverUptimeSecs": 0,
-        "rVersion": "20368.d55ec22.master"
+        "rVersion": "20368.d55ec22.main"
       },
       "totalCapacityBytes": 0,
       "totalUsedBytes": 0,

--- a/cinder/volume/drivers/hitachi/hbsd_fc.py
+++ b/cinder/volume/drivers/hitachi/hbsd_fc.py
@@ -160,11 +160,11 @@ class HBSDFCDriver(cinder.volume.driver.FibreChannelDriver):
                 if added_hostgroup:
                     self._delete_hostgroup(port, gid, host_grp_name)
 
-    def add_hostgroup_master(self, hgs, master_wwns, host_ip, security_ports):
+    def add_hostgroup_main(self, hgs, main_wwns, host_ip, security_ports):
         target_ports = self.configuration.hitachi_target_ports
         group_request = self.configuration.hitachi_group_request
         wwns = []
-        for wwn in master_wwns:
+        for wwn in main_wwns:
             wwns.append(wwn.lower())
         if target_ports and group_request:
             host_grp_name = '%s%s' % (basic_lib.NAME_PREFIX, host_ip)
@@ -232,7 +232,7 @@ class HBSDFCDriver(cinder.volume.driver.FibreChannelDriver):
         hostgroups = []
         security_ports = self._get_hostgroup_info(
             hostgroups, properties['wwpns'], login=False)
-        self.add_hostgroup_master(hostgroups, properties['wwpns'],
+        self.add_hostgroup_main(hostgroups, properties['wwpns'],
                                   properties['ip'], security_ports)
         self.add_hostgroup_pair(self.pair_hostgroups)
 
@@ -374,7 +374,7 @@ class HBSDFCDriver(cinder.volume.driver.FibreChannelDriver):
             hostgroups = []
             security_ports = self._get_hostgroup_info(
                 hostgroups, connector['wwpns'], login=True)
-            self.add_hostgroup_master(hostgroups, connector['wwpns'],
+            self.add_hostgroup_main(hostgroups, connector['wwpns'],
                                       connector['ip'], security_ports)
 
         if src_hgs is self.pair_hostgroups:

--- a/cinder/volume/drivers/hitachi/hbsd_iscsi.py
+++ b/cinder/volume/drivers/hitachi/hbsd_iscsi.py
@@ -203,12 +203,12 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
         if ports:
             self._fill_groups(hgs, ports, target_iqn, target_alias, add_iqn)
 
-    def add_hostgroup_master(self, hgs, master_iqn, host_ip, security_ports):
+    def add_hostgroup_main(self, hgs, main_iqn, host_ip, security_ports):
         target_ports = self.configuration.hitachi_target_ports
         group_request = self.configuration.hitachi_group_request
         target_alias = '%s%s' % (basic_lib.NAME_PREFIX, host_ip)
         if target_ports and group_request:
-            target_iqn = '%s.target' % master_iqn
+            target_iqn = '%s.target' % main_iqn
 
             diff_ports = []
             for port in security_ports:
@@ -219,7 +219,7 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
                     diff_ports.append(port)
 
             self.add_hostgroup_core(hgs, diff_ports, target_iqn,
-                                    target_alias, master_iqn)
+                                    target_alias, main_iqn)
         if not hgs:
             raise exception.HBSDError(message=basic_lib.output_err(649))
 
@@ -232,7 +232,7 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
         hostgroups = []
         security_ports = self._get_hostgroup_info_iscsi(
             hostgroups, properties['initiator'])
-        self.add_hostgroup_master(hostgroups, properties['initiator'],
+        self.add_hostgroup_main(hostgroups, properties['initiator'],
                                   properties['ip'], security_ports)
 
     def _get_properties(self, volume, hostgroups):
@@ -326,7 +326,7 @@ class HBSDISCSIDriver(cinder.volume.driver.ISCSIDriver):
             hostgroups = []
             security_ports = self._get_hostgroup_info_iscsi(
                 hostgroups, connector['initiator'])
-            self.add_hostgroup_master(hostgroups, connector['initiator'],
+            self.add_hostgroup_main(hostgroups, connector['initiator'],
                                       connector['ip'], security_ports)
 
         self._add_target(hostgroups, ldev)

--- a/cinder/volume/drivers/violin/v6000_fcp.py
+++ b/cinder/volume/drivers/violin/v6000_fcp.py
@@ -430,13 +430,13 @@ class V6000FCDriver(driver.FibreChannelDriver):
         free_gb = 0
         v = self.common.vip
 
-        master_cluster_id = v.basic.get_node_values(
-            '/cluster/state/master_id').values()[0]
+        main_cluster_id = v.basic.get_node_values(
+            '/cluster/state/main_id').values()[0]
 
         bn1 = "/vshare/state/global/%s/container/%s/total_bytes" \
-            % (master_cluster_id, self.common.container)
+            % (main_cluster_id, self.common.container)
         bn2 = "/vshare/state/global/%s/container/%s/free_bytes" \
-            % (master_cluster_id, self.common.container)
+            % (main_cluster_id, self.common.container)
         resp = v.basic.get_node_values([bn1, bn2])
 
         if bn1 in resp:

--- a/cinder/volume/drivers/violin/v6000_iscsi.py
+++ b/cinder/volume/drivers/violin/v6000_iscsi.py
@@ -449,13 +449,13 @@ class V6000ISCSIDriver(driver.ISCSIDriver):
         free_gb = 0
         v = self.common.vip
 
-        master_cluster_id = v.basic.get_node_values(
-            '/cluster/state/master_id').values()[0]
+        main_cluster_id = v.basic.get_node_values(
+            '/cluster/state/main_id').values()[0]
 
         bn1 = "/vshare/state/global/%s/container/%s/total_bytes" \
-            % (master_cluster_id, self.common.container)
+            % (main_cluster_id, self.common.container)
         bn2 = "/vshare/state/global/%s/container/%s/free_bytes" \
-            % (master_cluster_id, self.common.container)
+            % (main_cluster_id, self.common.container)
         resp = v.basic.get_node_values([bn1, bn2])
 
         if bn1 in resp:

--- a/expostack/congress/doc/source/conf.py
+++ b/expostack/congress/doc/source/conf.py
@@ -41,8 +41,8 @@ bug_tag = ''
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'congress'

--- a/expostack/congress/releasenotes/source/conf.py
+++ b/expostack/congress/releasenotes/source/conf.py
@@ -53,8 +53,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Congress Release Notes'

--- a/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python/tests/t052import.py
+++ b/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python/tests/t052import.py
@@ -69,10 +69,10 @@ class T(testbase.ANTLRTest):
         return TLexer
 
 
-    def execParser(self, grammar, grammarEntry, slaves, input):
-        for slave in slaves:
-            parserName = self.writeInlineGrammar(slave)[0]
-            # slave parsers are imported as normal python modules
+    def execParser(self, grammar, grammarEntry, subordinates, input):
+        for subordinate in subordinates:
+            parserName = self.writeInlineGrammar(subordinate)[0]
+            # subordinate parsers are imported as normal python modules
             # to force reloading current version, purge module from sys.modules
             try:
                 del sys.modules[parserName+'Parser']
@@ -90,10 +90,10 @@ class T(testbase.ANTLRTest):
         return parser._output
 
 
-    def execLexer(self, grammar, slaves, input):
-        for slave in slaves:
-            parserName = self.writeInlineGrammar(slave)[0]
-            # slave parsers are imported as normal python modules
+    def execLexer(self, grammar, subordinates, input):
+        for subordinate in subordinates:
+            parserName = self.writeInlineGrammar(subordinate)[0]
+            # subordinate parsers are imported as normal python modules
             # to force reloading current version, purge module from sys.modules
             try:
                 del sys.modules[parserName+'Parser']
@@ -127,7 +127,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorInvokesDelegateRule(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S1;
         options {
@@ -142,7 +142,7 @@ class T(testbase.ANTLRTest):
         a : B { self.capture("S.a") } ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M1;
         options {
@@ -155,8 +155,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave],
+            main, 's',
+            subordinates=[subordinate],
             input="b"
             )
 
@@ -167,25 +167,25 @@ class T(testbase.ANTLRTest):
         #     // must generate something like:
         #          // public int a(int x) throws RecognitionException { return gS.a(x); }
         #        // in M.
-        #        String slave =
+        #        String subordinate =
         #        "parser grammar S;\n" +
         #        "a : B {System.out.print(\"S.a\");} ;\n";
         #        mkdir(tmpdir);
-        #        writeFile(tmpdir, "S.g", slave);
-        #        String master =
+        #        writeFile(tmpdir, "S.g", subordinate);
+        #        String main =
         #        "grammar M;\n" +
         #        "import S;\n" +
         #        "s : a {System.out.println($a.text);} ;\n" +
         #        "B : 'b' ;" + // defines B from inherited token space
         #        "WS : (' '|'\\n') {skip();} ;\n" ;
-        #        String found = execParser("M.g", master, "MParser", "MLexer",
+        #        String found = execParser("M.g", main, "MParser", "MLexer",
         #                                    "s", "b", debug);
         #        assertEquals("S.ab\n", found);
         #        }
 
 
     def testDelegatorInvokesDelegateRuleWithArgs(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S2;
         options {
@@ -198,7 +198,7 @@ class T(testbase.ANTLRTest):
         a[x] returns [y] : B {self.capture("S.a"); $y="1000";} ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M2;
         options {
@@ -211,8 +211,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave],
+            main, 's',
+            subordinates=[subordinate],
             input="b"
             )
 
@@ -220,7 +220,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorAccessesDelegateMembers(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S3;
         options {
@@ -236,7 +236,7 @@ class T(testbase.ANTLRTest):
         a : B ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M3;        // uses no rules from the import
         options {
@@ -248,8 +248,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave],
+            main, 's',
+            subordinates=[subordinate],
             input="b"
             )
 
@@ -257,7 +257,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorInvokesFirstVersionOfDelegateRule(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S4;
         options {
@@ -271,7 +271,7 @@ class T(testbase.ANTLRTest):
         b : B ;
         ''')
 
-        slave2 = textwrap.dedent(
+        subordinate2 = textwrap.dedent(
         r'''
         parser grammar T4;
         options {
@@ -284,7 +284,7 @@ class T(testbase.ANTLRTest):
         a : B {self.capture("T.a");} ; // hidden by S.a
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M4;
         options {
@@ -297,8 +297,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave, slave2],
+            main, 's',
+            subordinates=[subordinate, subordinate2],
             input="b"
             )
 
@@ -306,7 +306,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatesSeeSameTokenType(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S5; // A, B, C token type order
         options {
@@ -320,7 +320,7 @@ class T(testbase.ANTLRTest):
         x : A {self.capture("S.x ");} ;
         ''')
 
-        slave2 = textwrap.dedent(
+        subordinate2 = textwrap.dedent(
         r'''
         parser grammar T5;
         options {
@@ -334,7 +334,7 @@ class T(testbase.ANTLRTest):
         y : A {self.capture("T.y");} ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M5;
         options {
@@ -349,8 +349,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave, slave2],
+            main, 's',
+            subordinates=[subordinate, subordinate2],
             input="aa"
             )
 
@@ -360,20 +360,20 @@ class T(testbase.ANTLRTest):
         # @Test public void testDelegatesSeeSameTokenType2() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" + // A, B, C token type order
         #                 "tokens { A; B; C; }\n" +
         #                 "x : A {System.out.println(\"S.x\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String slave2 =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String subordinate2 =
         #                 "parser grammar T;\n" +
         #                 "tokens { C; B; A; }\n" + // reverse order
         #                 "y : A {System.out.println(\"T.y\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "T.g", slave2);
+        #         writeFile(tmpdir, "T.g", subordinate2);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S,T;\n" +
         #                 "s : x y ;\n" + // matches AA, which should be "aa"
@@ -381,7 +381,7 @@ class T(testbase.ANTLRTest):
         #                 "A : 'a' ;\n" +
         #                 "C : 'c' ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -406,20 +406,20 @@ class T(testbase.ANTLRTest):
         #         // for now, we don't allow combined to import combined
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "grammar S;\n" + // A, B, C token type order
         #                 "tokens { A; B; C; }\n" +
         #                 "x : 'x' INT {System.out.println(\"S.x\");} ;\n" +
         #                 "INT : '0'..'9'+ ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
+        #         writeFile(tmpdir, "S.g", subordinate);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "s : x INT ;\n";
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -435,25 +435,25 @@ class T(testbase.ANTLRTest):
         # @Test public void testSameStringTwoNames() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "tokens { A='a'; }\n" +
         #                 "x : A {System.out.println(\"S.x\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String slave2 =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String subordinate2 =
         #                 "parser grammar T;\n" +
         #                 "tokens { X='a'; }\n" +
         #                 "y : X {System.out.println(\"T.y\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "T.g", slave2);
+        #         writeFile(tmpdir, "T.g", subordinate2);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S,T;\n" +
         #                 "s : x y ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -488,25 +488,25 @@ class T(testbase.ANTLRTest):
         # @Test public void testSameNameTwoStrings() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "tokens { A='a'; }\n" +
         #                 "x : A {System.out.println(\"S.x\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String slave2 =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String subordinate2 =
         #                 "parser grammar T;\n" +
         #                 "tokens { A='x'; }\n" +
         #                 "y : A {System.out.println(\"T.y\");} ;\n";
                 
-        #         writeFile(tmpdir, "T.g", slave2);
+        #         writeFile(tmpdir, "T.g", subordinate2);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S,T;\n" +
         #                 "s : x y ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -541,20 +541,20 @@ class T(testbase.ANTLRTest):
         # @Test public void testImportedTokenVocabIgnoredWithWarning() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "options {tokenVocab=whatever;}\n" +
         #                 "tokens { A='a'; }\n" +
         #                 "x : A {System.out.println(\"S.x\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
+        #         writeFile(tmpdir, "S.g", subordinate);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "s : x ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -579,24 +579,24 @@ class T(testbase.ANTLRTest):
         # @Test public void testImportedTokenVocabWorksInRoot() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "tokens { A='a'; }\n" +
         #                 "x : A {System.out.println(\"S.x\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
+        #         writeFile(tmpdir, "S.g", subordinate);
 
         #         String tokens =
         #                 "A=99\n";
         #         writeFile(tmpdir, "Test.tokens", tokens);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "options {tokenVocab=Test;}\n" +
         #                 "import S;\n" +
         #                 "s : x ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -620,18 +620,18 @@ class T(testbase.ANTLRTest):
         # @Test public void testSyntaxErrorsInImportsNotThrownOut() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "options {toke\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
+        #         writeFile(tmpdir, "S.g", subordinate);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "s : x ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -646,18 +646,18 @@ class T(testbase.ANTLRTest):
         # @Test public void testSyntaxErrorsInImportsNotThrownOut2() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 ": A {System.out.println(\"S.x\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
+        #         writeFile(tmpdir, "S.g", subordinate);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "s : x ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -671,7 +671,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorRuleOverridesDelegate(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S6;
         options {
@@ -685,7 +685,7 @@ class T(testbase.ANTLRTest):
         b : B ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M6;
         options {
@@ -697,8 +697,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 'a',
-            slaves=[slave],
+            main, 'a',
+            subordinates=[subordinate],
             input="c"
             )
 
@@ -706,7 +706,7 @@ class T(testbase.ANTLRTest):
 
 
     #     @Test public void testDelegatorRuleOverridesLookaheadInDelegate() throws Exception {
-    #             String slave =
+    #             String subordinate =
     #                     "parser grammar JavaDecl;\n" +
     #                     "type : 'int' ;\n" +
     #                     "decl : type ID ';'\n" +
@@ -714,8 +714,8 @@ class T(testbase.ANTLRTest):
     #                     "     ;\n" +
     #                     "init : '=' INT ;\n" ;
     #             mkdir(tmpdir);
-    #             writeFile(tmpdir, "JavaDecl.g", slave);
-    #             String master =
+    #             writeFile(tmpdir, "JavaDecl.g", subordinate);
+    #             String main =
     #                     "grammar Java;\n" +
     #                     "import JavaDecl;\n" +
     #                     "prog : decl ;\n" +
@@ -725,31 +725,31 @@ class T(testbase.ANTLRTest):
     #                     "INT : '0'..'9'+ ;\n" +
     #                     "WS : (' '|'\\n') {skip();} ;\n" ;
     #             // for float to work in decl, type must be overridden
-    #             String found = execParser("Java.g", master, "JavaParser", "JavaLexer",
+    #             String found = execParser("Java.g", main, "JavaParser", "JavaLexer",
     #                                                               "prog", "float x = 3;", debug);
     #             assertEquals("JavaDecl: floatx=3;\n", found);
     #     }
 
     # @Test public void testDelegatorRuleOverridesDelegates() throws Exception {
-    #     String slave =
+    #     String subordinate =
     #         "parser grammar S;\n" +
     #         "a : b {System.out.println(\"S.a\");} ;\n" +
     #         "b : B ;\n" ;
     #     mkdir(tmpdir);
-    #     writeFile(tmpdir, "S.g", slave);
+    #     writeFile(tmpdir, "S.g", subordinate);
 
-    #     String slave2 =
+    #     String subordinate2 =
     #         "parser grammar T;\n" +
     #         "tokens { A='x'; }\n" +
     #         "b : B {System.out.println(\"T.b\");} ;\n";
-    #     writeFile(tmpdir, "T.g", slave2);
+    #     writeFile(tmpdir, "T.g", subordinate2);
 
-    #     String master =
+    #     String main =
     #         "grammar M;\n" +
     #         "import S, T;\n" +
     #         "b : 'b'|'c' {System.out.println(\"M.b\");}|B|A ;\n" +
     #         "WS : (' '|'\\n') {skip();} ;\n" ;
-    #     String found = execParser("M.g", master, "MParser", "MLexer",
+    #     String found = execParser("M.g", main, "MParser", "MLexer",
     #                               "a", "c", debug);
     #     assertEquals("M.b\n" +
     #                  "S.a\n", found);
@@ -758,7 +758,7 @@ class T(testbase.ANTLRTest):
     # LEXER INHERITANCE
 
     def testLexerDelegatorInvokesDelegateRule(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         lexer grammar S7;
         options {
@@ -772,7 +772,7 @@ class T(testbase.ANTLRTest):
         C : 'c' ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         lexer grammar M7;
         options {
@@ -784,8 +784,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execLexer(
-            master,
-            slaves=[slave],
+            main,
+            subordinates=[subordinate],
             input="abc"
             )
 
@@ -793,7 +793,7 @@ class T(testbase.ANTLRTest):
 
 
     def testLexerDelegatorRuleOverridesDelegate(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         lexer grammar S8;
         options {
@@ -806,7 +806,7 @@ class T(testbase.ANTLRTest):
         A : 'a' {self.capture("S.A")} ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         lexer grammar M8;
         options {
@@ -818,8 +818,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execLexer(
-            master,
-            slaves=[slave],
+            main,
+            subordinates=[subordinate],
             input="a"
             )
 
@@ -828,17 +828,17 @@ class T(testbase.ANTLRTest):
         # @Test public void testLexerDelegatorRuleOverridesDelegateLeavingNoRules() throws Exception {
         #         // M.Tokens has nothing to predict tokens from S.  Should
         #         // not include S.Tokens alt in this case?
-        #         String slave =
+        #         String subordinate =
         #                 "lexer grammar S;\n" +
         #                 "A : 'a' {System.out.println(\"S.A\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String master =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String main =
         #                 "lexer grammar M;\n" +
         #                 "import S;\n" +
         #                 "A : 'a' {System.out.println(\"M.A\");} ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         writeFile(tmpdir, "/M.g", master);
+        #         writeFile(tmpdir, "/M.g", main);
 
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
@@ -869,16 +869,16 @@ class T(testbase.ANTLRTest):
         # @Test public void testInvalidImportMechanism() throws Exception {
         #         // M.Tokens has nothing to predict tokens from S.  Should
         #         // not include S.Tokens alt in this case?
-        #         String slave =
+        #         String subordinate =
         #                 "lexer grammar S;\n" +
         #                 "A : 'a' {System.out.println(\"S.A\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String master =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String main =
         #                 "tree grammar M;\n" +
         #                 "import S;\n" +
         #                 "a : A ;";
-        #         writeFile(tmpdir, "/M.g", master);
+        #         writeFile(tmpdir, "/M.g", main);
 
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
@@ -900,22 +900,22 @@ class T(testbase.ANTLRTest):
         #         // if this compiles, it means that synpred1_S is defined in S.java
         #         // but not MParser.java.  MParser has its own synpred1_M which must
         #         // be separate to compile.
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "a : 'a' {System.out.println(\"S.a1\");}\n" +
         #                 "  | 'a' {System.out.println(\"S.a2\");}\n" +
         #                 "  ;\n" +
         #                 "b : 'x' | 'y' {;} ;\n"; // preds generated but not need in DFA here
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String master =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String main =
         #                 "grammar M;\n" +
         #                 "options {backtrack=true;}\n" +
         #                 "import S;\n" +
         #                 "start : a b ;\n" +
         #                 "nonsense : 'q' | 'q' {;} ;" + // forces def of preds here in M
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         String found = execParser("M.g", master, "MParser", "MLexer",
+        #         String found = execParser("M.g", main, "MParser", "MLexer",
         #                                                           "start", "ax", debug);
         #         assertEquals("S.a1\n", found);
         # }
@@ -923,18 +923,18 @@ class T(testbase.ANTLRTest):
         # @Test public void testKeywordVSIDGivesNoWarning() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "lexer grammar S;\n" +
         #                 "A : 'abc' {System.out.println(\"S.A\");} ;\n" +
         #                 "ID : 'a'..'z'+ ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String master =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "a : A {System.out.println(\"M.a\");} ;\n" +
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         String found = execParser("M.g", master, "MParser", "MLexer",
+        #         String found = execParser("M.g", main, "MParser", "MLexer",
         #                                                           "a", "abc", debug);
 
         #         assertEquals("unexpected errors: "+equeue, 0, equeue.errors.size());
@@ -946,12 +946,12 @@ class T(testbase.ANTLRTest):
         # @Test public void testWarningForUndefinedToken() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "lexer grammar S;\n" +
         #                 "A : 'abc' {System.out.println(\"S.A\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String master =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "a : ABC A {System.out.println(\"M.a\");} ;\n" +
@@ -959,7 +959,7 @@ class T(testbase.ANTLRTest):
         #         // A is defined in S but M should still see it and not give warning.
         #         // only problem is ABC.
 
-        #         rawGenerateAndBuildRecognizer("M.g", master, "MParser", "MLexer", debug);
+        #         rawGenerateAndBuildRecognizer("M.g", main, "MParser", "MLexer", debug);
 
         #         assertEquals("unexpected errors: "+equeue, 0, equeue.errors.size());
         #         assertEquals("unexpected warnings: "+equeue, 1, equeue.warnings.size());
@@ -973,23 +973,23 @@ class T(testbase.ANTLRTest):
         # @Test public void test3LevelImport() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar T;\n" +
         #                 "a : T ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "T.g", slave);
-        #         String slave2 =
+        #         writeFile(tmpdir, "T.g", subordinate);
+        #         String subordinate2 =
         #                 "parser grammar S;\n" + // A, B, C token type order
         #                 "import T;\n" +
         #                 "a : S ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave2);
+        #         writeFile(tmpdir, "S.g", subordinate2);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "a : M ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -1011,7 +1011,7 @@ class T(testbase.ANTLRTest):
         #         assertEquals("unexpected errors: "+equeue, 0, equeue.errors.size());
 
         #         boolean ok =
-        #                 rawGenerateAndBuildRecognizer("M.g", master, "MParser", null, false);
+        #                 rawGenerateAndBuildRecognizer("M.g", main, "MParser", null, false);
         #         boolean expecting = true; // should be ok
         #         assertEquals(expecting, ok);
         # }
@@ -1019,40 +1019,40 @@ class T(testbase.ANTLRTest):
         # @Test public void testBigTreeOfImports() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar T;\n" +
         #                 "x : T ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "T.g", slave);
-        #         slave =
+        #         writeFile(tmpdir, "T.g", subordinate);
+        #         subordinate =
         #                 "parser grammar S;\n" +
         #                 "import T;\n" +
         #                 "y : S ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
+        #         writeFile(tmpdir, "S.g", subordinate);
 
-        #         slave =
+        #         subordinate =
         #                 "parser grammar C;\n" +
         #                 "i : C ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "C.g", slave);
-        #         slave =
+        #         writeFile(tmpdir, "C.g", subordinate);
+        #         subordinate =
         #                 "parser grammar B;\n" +
         #                 "j : B ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "B.g", slave);
-        #         slave =
+        #         writeFile(tmpdir, "B.g", subordinate);
+        #         subordinate =
         #                 "parser grammar A;\n" +
         #                 "import B,C;\n" +
         #                 "k : A ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "A.g", slave);
+        #         writeFile(tmpdir, "A.g", subordinate);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S,A;\n" +
         #                 "a : M ;\n" ;
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -1074,7 +1074,7 @@ class T(testbase.ANTLRTest):
         #         assertEquals("unexpected errors: "+equeue, 0, equeue.errors.size());
 
         #         boolean ok =
-        #                 rawGenerateAndBuildRecognizer("M.g", master, "MParser", null, false);
+        #                 rawGenerateAndBuildRecognizer("M.g", main, "MParser", null, false);
         #         boolean expecting = true; // should be ok
         #         assertEquals(expecting, ok);
         # }
@@ -1082,23 +1082,23 @@ class T(testbase.ANTLRTest):
         # @Test public void testRulesVisibleThroughMultilevelImport() throws Exception {
         #         ErrorQueue equeue = new ErrorQueue();
         #         ErrorManager.setErrorListener(equeue);
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar T;\n" +
         #                 "x : T ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "T.g", slave);
-        #         String slave2 =
+        #         writeFile(tmpdir, "T.g", subordinate);
+        #         String subordinate2 =
         #                 "parser grammar S;\n" + // A, B, C token type order
         #                 "import T;\n" +
         #                 "a : S ;\n" ;
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave2);
+        #         writeFile(tmpdir, "S.g", subordinate2);
 
-        #         String master =
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "a : M x ;\n" ; // x MUST BE VISIBLE TO M
-        #         writeFile(tmpdir, "M.g", master);
+        #         writeFile(tmpdir, "M.g", main);
         #         Tool antlr = newTool(new String[] {"-lib", tmpdir});
         #         CompositeGrammar composite = new CompositeGrammar();
         #         Grammar g = new Grammar(antlr,tmpdir+"/M.g",composite);
@@ -1180,12 +1180,12 @@ class T(testbase.ANTLRTest):
         # }
 
         # @Test public void testHeadersPropogatedCorrectlyToImportedGrammars() throws Exception {
-        #         String slave =
+        #         String subordinate =
         #                 "parser grammar S;\n" +
         #                 "a : B {System.out.print(\"S.a\");} ;\n";
         #         mkdir(tmpdir);
-        #         writeFile(tmpdir, "S.g", slave);
-        #         String master =
+        #         writeFile(tmpdir, "S.g", subordinate);
+        #         String main =
         #                 "grammar M;\n" +
         #                 "import S;\n" +
         #                 "@header{package mypackage;}\n" +
@@ -1193,7 +1193,7 @@ class T(testbase.ANTLRTest):
         #                 "s : a ;\n" +
         #                 "B : 'b' ;" + // defines B from inherited token space
         #                 "WS : (' '|'\\n') {skip();} ;\n" ;
-        #         boolean ok = antlr("M.g", "M.g", master, debug);
+        #         boolean ok = antlr("M.g", "M.g", main, debug);
         #         boolean expecting = true; // should be ok
         #         assertEquals(expecting, ok);
         # }

--- a/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python/tests/t054main.py
+++ b/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python/tests/t054main.py
@@ -271,7 +271,7 @@ class T(testbase.ANTLRTest):
 
 
     def testGrammarImport(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
             r'''
             parser grammar T8S;
             options {
@@ -281,15 +281,15 @@ class T(testbase.ANTLRTest):
             a : B;
             ''')
 
-        parserName = self.writeInlineGrammar(slave)[0]
-        # slave parsers are imported as normal python modules
+        parserName = self.writeInlineGrammar(subordinate)[0]
+        # subordinate parsers are imported as normal python modules
         # to force reloading current version, purge module from sys.modules
         try:
             del sys.modules[parserName+'Parser']
         except KeyError:
             pass
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
             r'''
             grammar T8M;
             options {
@@ -303,7 +303,7 @@ class T(testbase.ANTLRTest):
 
         stdout = StringIO()
 
-        lexerMod, parserMod = self.compileInlineGrammar(master, returnModule=True)
+        lexerMod, parserMod = self.compileInlineGrammar(main, returnModule=True)
         parserMod.main(
             ['import.py', '--rule', 's'],
             stdin=StringIO("b"),

--- a/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python3/tests/t052import.py
+++ b/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python3/tests/t052import.py
@@ -69,10 +69,10 @@ class T(testbase.ANTLRTest):
         return TLexer
 
 
-    def execParser(self, grammar, grammarEntry, slaves, input):
-        for slave in slaves:
-            parserName = self.writeInlineGrammar(slave)[0]
-            # slave parsers are imported as normal python modules
+    def execParser(self, grammar, grammarEntry, subordinates, input):
+        for subordinate in subordinates:
+            parserName = self.writeInlineGrammar(subordinate)[0]
+            # subordinate parsers are imported as normal python modules
             # to force reloading current version, purge module from sys.modules
             if parserName + 'Parser' in sys.modules:
                 del sys.modules[parserName + 'Parser']
@@ -88,10 +88,10 @@ class T(testbase.ANTLRTest):
         return parser._output
 
 
-    def execLexer(self, grammar, slaves, input):
-        for slave in slaves:
-            parserName = self.writeInlineGrammar(slave)[0]
-            # slave parsers are imported as normal python modules
+    def execLexer(self, grammar, subordinates, input):
+        for subordinate in subordinates:
+            parserName = self.writeInlineGrammar(subordinate)[0]
+            # subordinate parsers are imported as normal python modules
             # to force reloading current version, purge module from sys.modules
             if parserName + 'Parser' in sys.modules:
                 del sys.modules[parserName + 'Parser']
@@ -112,7 +112,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorInvokesDelegateRule(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S1;
         options {
@@ -127,7 +127,7 @@ class T(testbase.ANTLRTest):
         a : B { self.capture("S.a") } ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M1;
         options {
@@ -140,8 +140,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave],
+            main, 's',
+            subordinates=[subordinate],
             input="b"
             )
 
@@ -149,7 +149,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorInvokesDelegateRuleWithArgs(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S2;
         options {
@@ -162,7 +162,7 @@ class T(testbase.ANTLRTest):
         a[x] returns [y] : B {self.capture("S.a"); $y="1000";} ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M2;
         options {
@@ -175,8 +175,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave],
+            main, 's',
+            subordinates=[subordinate],
             input="b"
             )
 
@@ -184,7 +184,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorAccessesDelegateMembers(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S3;
         options {
@@ -200,7 +200,7 @@ class T(testbase.ANTLRTest):
         a : B ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M3;        // uses no rules from the import
         options {
@@ -212,8 +212,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave],
+            main, 's',
+            subordinates=[subordinate],
             input="b"
             )
 
@@ -221,7 +221,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorInvokesFirstVersionOfDelegateRule(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S4;
         options {
@@ -235,7 +235,7 @@ class T(testbase.ANTLRTest):
         b : B ;
         ''')
 
-        slave2 = textwrap.dedent(
+        subordinate2 = textwrap.dedent(
         r'''
         parser grammar T4;
         options {
@@ -248,7 +248,7 @@ class T(testbase.ANTLRTest):
         a : B {self.capture("T.a");} ; // hidden by S.a
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M4;
         options {
@@ -261,8 +261,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave, slave2],
+            main, 's',
+            subordinates=[subordinate, subordinate2],
             input="b"
             )
 
@@ -270,7 +270,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatesSeeSameTokenType(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S5; // A, B, C token type order
         options {
@@ -284,7 +284,7 @@ class T(testbase.ANTLRTest):
         x : A {self.capture("S.x ");} ;
         ''')
 
-        slave2 = textwrap.dedent(
+        subordinate2 = textwrap.dedent(
         r'''
         parser grammar T5;
         options {
@@ -298,7 +298,7 @@ class T(testbase.ANTLRTest):
         y : A {self.capture("T.y");} ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M5;
         options {
@@ -313,8 +313,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 's',
-            slaves=[slave, slave2],
+            main, 's',
+            subordinates=[subordinate, subordinate2],
             input="aa"
             )
 
@@ -322,7 +322,7 @@ class T(testbase.ANTLRTest):
 
 
     def testDelegatorRuleOverridesDelegate(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         parser grammar S6;
         options {
@@ -336,7 +336,7 @@ class T(testbase.ANTLRTest):
         b : B ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         grammar M6;
         options {
@@ -348,8 +348,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execParser(
-            master, 'a',
-            slaves=[slave],
+            main, 'a',
+            subordinates=[subordinate],
             input="c"
             )
 
@@ -359,7 +359,7 @@ class T(testbase.ANTLRTest):
     # LEXER INHERITANCE
 
     def testLexerDelegatorInvokesDelegateRule(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         lexer grammar S7;
         options {
@@ -373,7 +373,7 @@ class T(testbase.ANTLRTest):
         C : 'c' ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         lexer grammar M7;
         options {
@@ -385,8 +385,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execLexer(
-            master,
-            slaves=[slave],
+            main,
+            subordinates=[subordinate],
             input="abc"
             )
 
@@ -394,7 +394,7 @@ class T(testbase.ANTLRTest):
 
 
     def testLexerDelegatorRuleOverridesDelegate(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
         r'''
         lexer grammar S8;
         options {
@@ -407,7 +407,7 @@ class T(testbase.ANTLRTest):
         A : 'a' {self.capture("S.A")} ;
         ''')
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
         r'''
         lexer grammar M8;
         options {
@@ -419,8 +419,8 @@ class T(testbase.ANTLRTest):
         ''')
 
         found = self.execLexer(
-            master,
-            slaves=[slave],
+            main,
+            subordinates=[subordinate],
             input="a"
             )
 

--- a/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python3/tests/t054main.py
+++ b/expostack/congress/thirdparty/antlr3-antlr-3.5/runtime/Python3/tests/t054main.py
@@ -264,7 +264,7 @@ class T(testbase.ANTLRTest):
 
 
     def testGrammarImport(self):
-        slave = textwrap.dedent(
+        subordinate = textwrap.dedent(
             r'''
             parser grammar T8S;
             options {
@@ -274,13 +274,13 @@ class T(testbase.ANTLRTest):
             a : B;
             ''')
 
-        parserName = self.writeInlineGrammar(slave)[0]
-        # slave parsers are imported as normal python modules
+        parserName = self.writeInlineGrammar(subordinate)[0]
+        # subordinate parsers are imported as normal python modules
         # to force reloading current version, purge module from sys.modules
         if parserName + 'Parser' in sys.modules:
             del sys.modules[parserName+'Parser']
 
-        master = textwrap.dedent(
+        main = textwrap.dedent(
             r'''
             grammar T8M;
             options {
@@ -294,7 +294,7 @@ class T(testbase.ANTLRTest):
 
         stdout = StringIO()
 
-        lexerMod, parserMod = self.compileInlineGrammar(master, returnModule=True)
+        lexerMod, parserMod = self.compileInlineGrammar(main, returnModule=True)
         parserMod.main(
             ['import.py', '--rule', 's'],
             stdin=StringIO("b"),


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.